### PR TITLE
Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,88 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.2)
-project(BeFoR64 Fortran)
+# The target of the library BeFoR64 is exported
+# as BeFoR64::BeFoR64 to a package config file for BeFoR64
+#
+# usage:
+#     find_package(BeFoR64)
+#     ...
+#     target_link_library(<target> BeFoR64)
+#
+# the config file is generatet in the build and install directories
 
-if(TARGET PENF)
-#    If lib PENF was added to the external project before BeFoR64
-else()
-add_subdirectory(src/third_party/PENF)
-endif()
+cmake_minimum_required(VERSION 3.10...3.13)
+project(BeFoR64 VERSION 1.1.3 LANGUAGES Fortran)
+
+# seach path for additional cmake modules
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
+
+
+# set export variables needed for building
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "${PROJECT_NAME}::")
+
+
+# generate the library and install instructions
 add_subdirectory(src/lib)
+
+if(NOT TARGET PENF)
+    add_subdirectory(src/third_party/PENF)
+endif()
+
+# testing
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+    set(main_project TRUE)
+else()
+    set(main_project FALSE)
+endif()
+
+include(CMakeDependentOption)
+cmake_dependent_option(BUILD_TESTING_${PROJECT_NAME}
+     "Build the testing tree for project ${PROJECT_NAME}." OFF
+     "BUILD_TESTING;NOT main_project" OFF
+)
+
+if (main_project AND NOT DEFINED BUILD_TESTING)
+    set(BUILD_TESTING ON)
+endif()
+
+if((main_project AND BUILD_TESTING) OR BUILD_TESTING_${PROJECT_NAME})
+    enable_testing()
+    add_subdirectory(src/tests)
+endif()
+
+# generate package config files
+include(GNUInstallDirs)
+set(project_config "${PROJECT_NAME}Config.cmake")
+set(cmake_files_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(config_build_dir "${CMAKE_CURRENT_BINARY_DIR}/${config_install_dir}")
+
+# export targets for install
+install(EXPORT ${TARGETS_EXPORT_NAME}
+    NAMESPACE
+        ${NAMESPACE}
+    DESTINATION
+        ${config_install_dir}
+    COMPONENT Development
+)
+
+# export targets into build
+export(EXPORT ${TARGETS_EXPORT_NAME}
+    NAMESPACE
+        ${NAMESPACE}
+    FILE
+        ${config_build_dir}/${TARGETS_EXPORT_NAME}.cmake
+)
+
+#create package config
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/PackageConfig.cmake.in ${cmake_files_dir}/${project_config}
+    INSTALL_DESTINATION ${config_install_dir}
+)
+install(FILES ${cmake_files_dir}/${project_config}
+    DESTINATION ${config_install_dir}
+)
+
+configure_package_config_file(cmake/PackageConfig.cmake.in ${config_build_dir}/${project_config}
+    INSTALL_DESTINATION ${config_build_dir}
+    INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/cmake/Modules/CheckFortranSourceRuns.cmake
+++ b/cmake/Modules/CheckFortranSourceRuns.cmake
@@ -1,0 +1,158 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckFortranSourceRuns
+----------------------
+
+Check if given Fortran source compiles and links into an executable and can
+subsequently be run.
+
+.. command:: check_fortran_source_runs
+
+  .. code-block:: cmake
+
+    check_fortran_source_runs(<code> <resultVar>
+        [SRC_EXT <extension>])
+
+  Check that the source supplied in ``<code>`` can be compiled as a Fortran source
+  file, linked as an executable and then run. The ``<code>`` must contain at
+  least ``program; end program`` statements. If the ``<code>`` could be built and run
+  successfully, the internal cache variable specified by ``<resultVar>`` will
+  be set to 1, otherwise it will be set to an value that evaluates to boolean
+  false (e.g. an empty string or an error message).
+
+  By default, the test source file will be given a ``.F90`` file extension. The
+  ``SRC_EXT`` option can be used to override this with ``.<extension>`` instead.
+
+  The underlying check is performed by the :command:`try_run` command. The
+  compile and link commands can be influenced by setting any of the following
+  variables prior to calling ``check_fortran_source_runs()``:
+
+  ``CMAKE_REQUIRED_FLAGS``
+    Additional flags to pass to the compiler. Note that the contents of
+    :variable:`CMAKE_Fortran_FLAGS <CMAKE_<LANG>_FLAGS>` and its associated
+    configuration-specific variable are automatically added to the compiler
+    command before the contents of ``CMAKE_REQUIRED_FLAGS``.
+
+  ``CMAKE_REQUIRED_DEFINITIONS``
+    A :ref:`;-list <CMake Language Lists>` of compiler definitions of the form
+    ``-DFOO`` or ``-DFOO=bar``. A definition for the name specified by
+    ``<resultVar>`` will also be added automatically.
+
+  ``CMAKE_REQUIRED_INCLUDES``
+    A :ref:`;-list <CMake Language Lists>` of header search paths to pass to
+    the compiler. These will be the only header search paths used by
+    ``try_run()``, i.e. the contents of the :prop_dir:`INCLUDE_DIRECTORIES`
+    directory property will be ignored.
+
+  ``CMAKE_REQUIRED_LINK_OPTIONS``
+    A :ref:`;-list <CMake Language Lists>` of options to add to the link
+    command (see :command:`try_run` for further details).
+
+  ``CMAKE_REQUIRED_LIBRARIES``
+    A :ref:`;-list <CMake Language Lists>` of libraries to add to the link
+    command. These can be the name of system libraries or they can be
+    :ref:`Imported Targets <Imported Targets>` (see :command:`try_run` for
+    further details).
+
+  ``CMAKE_REQUIRED_QUIET``
+    If this variable evaluates to a boolean true value, all status messages
+    associated with the check will be suppressed.
+
+  The check is only performed once, with the result cached in the variable
+  named by ``<resultVar>``. Every subsequent CMake run will re-use this cached
+  value rather than performing the check again, even if the ``<code>`` changes.
+  In order to force the check to be re-evaluated, the variable named by
+  ``<resultVar>`` must be manually removed from the cache.
+
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+macro(CHECK_Fortran_SOURCE_RUNS SOURCE VAR)
+  if(NOT DEFINED "${VAR}")
+    set(_SRC_EXT)
+    set(_key)
+    foreach(arg ${ARGN})
+      if("${arg}" MATCHES "^(SRC_EXT)$")
+        set(_key "${arg}")
+      elseif(_key)
+        list(APPEND _${_key} "${arg}")
+      else()
+        message(FATAL_ERROR "Unknown argument:\n  ${arg}\n")
+      endif()
+    endforeach()
+    if(NOT _SRC_EXT)
+      set(_SRC_EXT F90)
+    endif()
+    set(MACRO_CHECK_FUNCTION_DEFINITIONS
+      "-D${VAR} ${CMAKE_REQUIRED_FLAGS}")
+    if(CMAKE_REQUIRED_LINK_OPTIONS)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS
+        LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS})
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS)
+    endif()
+    if(CMAKE_REQUIRED_LIBRARIES)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES
+        LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES)
+    endif()
+    if(CMAKE_REQUIRED_INCLUDES)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES
+        "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}")
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES)
+    endif()
+    file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.${_SRC_EXT}"
+      "${SOURCE}\n")
+
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Performing Test ${VAR}")
+    endif()
+    try_run(${VAR}_EXITCODE ${VAR}_COMPILED
+      ${CMAKE_BINARY_DIR}
+      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.${_SRC_EXT}
+      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+      ${CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS}
+      ${CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES}
+      CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
+      -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
+      "${CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES}"
+      COMPILE_OUTPUT_VARIABLE OUTPUT)
+
+    # if it did not compile make the return value fail code of 1
+    if(NOT ${VAR}_COMPILED)
+      set(${VAR}_EXITCODE 1)
+    endif()
+    # if the return value was 0 then it worked
+    if("${${VAR}_EXITCODE}" EQUAL 0)
+      set(${VAR} 1 CACHE INTERNAL "Test ${VAR}")
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Success")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Performing Fortran SOURCE FILE Test ${VAR} succeeded with the following output:\n"
+        "${OUTPUT}\n"
+        "Return value: ${${VAR}}\n"
+        "Source file was:\n${SOURCE}\n")
+    else()
+      if(CMAKE_CROSSCOMPILING AND "${${VAR}_EXITCODE}" MATCHES  "FAILED_TO_RUN")
+        set(${VAR} "${${VAR}_EXITCODE}")
+      else()
+        set(${VAR} "" CACHE INTERNAL "Test ${VAR}")
+      endif()
+
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Failed")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Performing Fortran SOURCE FILE Test ${VAR} failed with the following output:\n"
+        "${OUTPUT}\n"
+        "Return value: ${${VAR}_EXITCODE}\n"
+        "Source file was:\n${SOURCE}\n")
+    endif()
+  endif()
+endmacro()

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,5 +1,98 @@
-ADD_LIBRARY(BeFoR64
+# set type specific output defaults
+include(GNUInstallDirs)
+
+SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+SET(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/modules")
+
+set(LIB BeFoR64)
+add_library(${LIB}
         befor64.F90
         befor64_pack_data_m.F90
-        )
-target_link_libraries(BeFoR64 PENF)
+)
+target_link_libraries(${LIB} PENF::PENF)
+
+
+add_library(${NAMESPACE}${LIB} ALIAS ${LIB})
+
+target_include_directories(${LIB}
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+)
+
+# set variables used for compile definitions of targets after support check
+include(CheckFortranSourceRuns)
+check_fortran_source_runs(
+    "program r16p_support;
+         integer, parameter :: r16p = selected_real_kind(33, 4931);
+         if(r16p < 0) stop 1;
+     end program r16p_support"
+     R16P_SUPPORTED
+     SRC_EXT f90)
+if(R16P_SUPPORTED)
+    set(r16p_supported "_R16P_SUPPORTED")
+endif()
+
+check_fortran_source_runs(
+    "program ascii_support;
+         integer, parameter :: ascii = selected_char_kind('ascii');
+         if(ascii < 0) stop 1;
+     end program ascii_support"
+    ASCII_SUPPORTED
+    SRC_EXT f90)
+if(ASCII_SUPPORTED)
+    set(ascii_supported "_ASCII_SUPPORTED")
+endif()
+
+check_fortran_source_runs(
+    "program ascii_neq_default;
+         integer, parameter :: ascii = selected_char_kind('ascii');
+         integer, parameter :: default = selected_char_kind('default');
+         if(ascii == default) stop 1;
+     end program ascii_neq_default"
+    ASCII_NEQ_DEFAULT
+    SRC_EXT f90
+)
+if(ASCII_NEQ_DEFAULT)
+    set(ascii_neq_default "_ASCII_NEQ_DEFAULT")
+endif()
+
+check_fortran_source_runs(
+    "program ucs4_support;
+         integer, parameter :: ucs4 = selected_char_kind('iso_10646');
+         if(ucs4 < 0) stop 1;
+     end program ucs4_support"
+    UCS4_SUPPORTED
+    SRC_EXT f90)
+if(UCS4_SUPPORTED)
+    set(ucs4_supported "_UCS4_SUPPORTED")
+endif()
+
+target_compile_definitions(${LIB}
+    PRIVATE
+        ${r16p_supported}
+        ${ascii_supported}
+        ${ascii_neq_default}
+        ${ucs4_supported}
+)
+
+set_target_properties(${LIB} PROPERTIES
+    VERSION
+        ${PROJECT_VERSION}
+    SOVERSION
+        ${PROJECT_VERSION_MAJOR}
+)
+
+# installation and export of targets
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+    COMPONENT Developement
+)
+
+install(TARGETS ${LIB} EXPORT ${TARGETS_EXPORT_NAME}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeLibraries
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+include(GNUInstallDirs)
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tests/${CMAKE_INSTALL_BINDIR}")
+
+function(add_befor64_doctest test_src libraries)
+    get_filename_component(test_name ${test_src} NAME_WE)
+    get_filename_component(test_dir ${test_src} DIRECTORY)
+    set(result_src "${test_dir}/${test_name}.result")
+
+    add_executable(${test_name} ${test_src})
+    foreach(lib IN LISTS libraries)
+        target_link_libraries(${test_name} ${lib})
+    endforeach()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+
+    file(STRINGS ${result_src} result_raw)
+    string(REGEX REPLACE "([+.])([^+.]*)" "\\\\\\1\\2" result ${result_raw})
+
+    set_tests_properties(${test_name} PROPERTIES
+        PASS_REGULAR_EXPRESSION "${result}"
+    )
+endfunction()
+
+file(GLOB_RECURSE befor64_doctests *.f90)
+
+foreach(befor64_doctest IN LISTS befor64_doctests)
+    add_befor64_doctest(${befor64_doctest} BeFoR64 PENF)
+endforeach()


### PR DESCRIPTION
@szaghi Sorry for some mess, this KISS approach worked fine as I was compiling BeFoR64 standalone or as part of my attempt to add cmake support to FiNeR. However, when I added a FiNeR to my real project (which uses Fortran and CMake), it turned out to stop working (due to the fact that my project organizes file in different manner compared to src/third_party).  So I adapted modern cmake 3.0 config from PENF project, now it seems to work fine at all levels (there is some R16 encode\decode incompatibility with gfortran-8, however, I  just comment them out in downstream for now). 

I still have some problems with paths in my FiNeR cmake config, to make it work I need to rewrite cmake config in accordance with the root build directory. As soon as I overcome it I will PR it too.

